### PR TITLE
Set $page to the user-visible container page if the hanna code is in a repeater field

### DIFF
--- a/TextformatterHannaCode.module
+++ b/TextformatterHannaCode.module
@@ -389,10 +389,20 @@ class TextformatterHannaCode extends Textformatter implements ConfigurableModule
 		foreach(wire() as $key => $value) {
 			if($key != 'page') $t->set($key, $value); 
 		}
-
+		
+		// set $page to the page containing the field, taking into account the repeater case
+		if ($this->page instanceof RepeaterPage) {
+			$repeaterPage = $this->page;
+			$page = $fieldGroup->getForPage();
+		}
+		else {
+			$page = $this->page;
+		}
+			
 		// populate $page and $hanna variables that are context specific
 		// note $page may be different from wire('page')
-		$t->set('page', $this->page);
+		if ($repeaterPage) $t->set('group', $repeaterPage);
+		$t->set('page', $page);
 		$t->set('hanna', $this); 
 
 		return $t->render();


### PR DESCRIPTION
Hi Ryan,

This proposal is intended to address an issue I ran into and which will bed best described by the corresponding PW forum message: http://processwire.com/talk/topic/3745-hanna-code/page-7#entry54326 

Although having $page set to the repeater page where the field is located is consistent with other parts of PW like the repeater templates, it can be confusing for the user not-so-aware-of-pw-internals.

And it makes the writing oh hanna codes more complex if you have to check for the repeater case inside the hanna code itself.

So IMO it would be better to have 2 separate variables to handle the various levels in the repeater case.

I've put it in a certain way here, but other options may be just as good:
- $page is the user-visible page containing the field where the hanna code is
- $group is the repeater page containing the field (or null)
- wire("page") is the rendered page

Also added a $group variable to refer to the repeater page (null if the field is not in a repeater).

Note: I haven't done any change to $this->page to avoid unwanted side effects, mainly because of my limited knowledge of PW. This means that $page, $hanna->page and wire("page") may have different values.
This may need to be changed in an released version. ;-)

Thanks for having a look at this pull-request

Jean-Luc
