### PR TITLE
Support for recursive Hanna code tags added and support for Hanna Code names with a dot and attributes added.

### DIFF
--- a/TextformatterHannaCode.module
+++ b/TextformatterHannaCode.module
@@ -75,7 +75,7 @@ class TextformatterHannaCode extends Textformatter implements ConfigurableModule
 	 * $value passed to the Textformatter's formatValue() function
 	 *
 	 */
-	protected $value; 
+	protected $value = '';
 
 	/**
 	 * $name of the current Hanna code
@@ -129,6 +129,9 @@ class TextformatterHannaCode extends Textformatter implements ConfigurableModule
 
 		$openTag = $this->openTag; 
 		$closeTag = $this->closeTag; 
+		$savedPage = $this->page;
+		$savedField = $this->field;
+		$savedValue = $this->value;
 		$this->page = $page;
 		$this->field = $field; 
 		$this->value = $value; 
@@ -185,9 +188,9 @@ class TextformatterHannaCode extends Textformatter implements ConfigurableModule
 		if(!$of) $this->page->of(false);
 
 		$value = $this->value; 	
-		$this->value = '';
-		$this->page = null;
-		$this->field = null;
+		$this->value = $savedValue;
+		$this->page = $savedPage;
+		$this->field = $savedField;
 	}
 
 	/**

--- a/TextformatterHannaCode.module
+++ b/TextformatterHannaCode.module
@@ -129,12 +129,6 @@ class TextformatterHannaCode extends Textformatter implements ConfigurableModule
 
 		$openTag = $this->openTag; 
 		$closeTag = $this->closeTag; 
-		$savedPage = $this->page;
-		$savedField = $this->field;
-		$savedValue = $this->value;
-		$this->page = $page;
-		$this->field = $field; 
-		$this->value = $value; 
 
 		// exit early when possible
 		if(strpos($value, $openTag) === false) return;
@@ -150,6 +144,14 @@ class TextformatterHannaCode extends Textformatter implements ConfigurableModule
 			'!';	
 
 		if(!preg_match_all($regx, $value, $matches)) return;
+
+		// save context for recursion
+		$savedPage = $this->page;
+		$savedField = $this->field;
+		$savedValue = $this->value;
+		$this->page = $page;
+		$this->field = $field;
+		$this->value = $value;
 
 		// save output formatting state and then ensure it is ON
 		$of = $this->page->of();
@@ -187,7 +189,9 @@ class TextformatterHannaCode extends Textformatter implements ConfigurableModule
 		// restore output formatting state
 		if(!$of) $this->page->of(false);
 
-		$value = $this->value; 	
+		$value = $this->value;
+
+		// restore context
 		$this->value = $savedValue;
 		$this->page = $savedPage;
 		$this->field = $savedField;

--- a/TextformatterHannaCode.module
+++ b/TextformatterHannaCode.module
@@ -239,7 +239,7 @@ class TextformatterHannaCode extends Textformatter implements ConfigurableModule
 			// allow for optional [[name_here attrs]] expression
 			// where the 'name' isn't specifically called out as an attribute
 			// but is the first symbol in the expression
-			if(preg_match('!^([-_a-z0-9]+)([\s,]|$)!i', $expression, $matches)) {
+			if(preg_match('!^([\.-_a-z0-9]+)([\s,]|$)!i', $expression, $matches)) {
 				$attrs['name'] = $matches[1]; 
 			}
 		}


### PR DESCRIPTION
Added support for Hanna Code names with a dot. Example: [[admin.email
reaptcha="true"]]

Previously the Hanna Code parser did not recognise dotted names when
attributes where passed as well.

Refer to
https://processwire.com/talk/topic/3745-hanna-code/page-11#entry81765
